### PR TITLE
Use canary API on canary domain

### DIFF
--- a/src/web/actions/api.ts
+++ b/src/web/actions/api.ts
@@ -1,6 +1,9 @@
 import { Message } from '../../common/models/message';
 
-const API_HOST = 'https://everythingissauce.com';
+const API_HOST =
+  location.hostname === 'canary.everythingissauce'
+  ? 'https://canary.everythingissauce.com'
+  : 'https://everythingissauce.com';
 
 export interface ApiResult {
   message: (Message | null);


### PR DESCRIPTION
When the web app is pushed to the canary domain it will now access the
canary API server instead of the production server.