### PR TITLE
Attempt to improve login UX

### DIFF
--- a/src/server/routes/account.ts
+++ b/src/server/routes/account.ts
@@ -74,4 +74,8 @@ account.get('/', authRoute(async (userId, req, res) => {
   res.success({user});
 }));
 
+account.get('/check', authRoute(async (userId, req, res) => {
+  res.success({});
+}));
+
 export default account;

--- a/src/web/actions/api-actions.ts
+++ b/src/web/actions/api-actions.ts
@@ -291,10 +291,18 @@ export function ignoreSuggestedContacts(contactId: string) {
 }
 
 export function getAllData() {
-  return (dispatch: Dispatch<State>) => {
-    dispatch(getAccount());
-    dispatch(getContacts());
-    dispatch(getInbox());
-    dispatch(getHistory());
-  };
+  return (dispatch: Dispatch<State>, getState: () => State) => api.get({
+    failure: 'CHECK_ACCOUNT_FAILURE',
+    name: 'CHECK_ACCOUNT',
+    requireAuth: true,
+    start: 'CHECK_ACCOUNT_START',
+    success: 'CHECK_ACCOUNT_SUCCESS',
+    onSuccess: () => {
+      dispatch(getAccount());
+      dispatch(getContacts());
+      dispatch(getInbox());
+      dispatch(getHistory());
+    },
+    url: `/api/2/account/check`,
+  })(dispatch, getState);
 }


### PR DESCRIPTION
If a user has not been logged in for a long time the app may go to the
inbox, load for a while, and then bump the user back to the login
screen.

Instead, try a lightweight request to ensure that the credentials are
still valid before attempting multiple slower queries.